### PR TITLE
Fix various source comment/documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ the future, other languages too.
 #### Generate beautiful documentation
 
 Documenting a script is hard but important: otherwise your users are
-clue-less about what each button of the controler does.  Mixco
+clue-less about what each button of the controller does.  Mixco
 encourages a style of programming known as
 [literate programming][litprog], which mixes code with documentation
 about what it does.  If you code in that style, it can generate
@@ -284,7 +284,7 @@ Please, log **bugs, questions or feature requests** in the
 
 We are also **happy to accept contributions**, either improvements to the
 frameworks, new factory scripts or documentation
-enhacements. [Fork us on GitHub][github] or by running:
+enhancements. [Fork us on GitHub][github] or by running:
 
 > ```
 > git clone https://github.com/arximboldi/mixco.git

--- a/script/korg_nanokontrol2.mixco.litcoffee
+++ b/script/korg_nanokontrol2.mixco.litcoffee
@@ -9,7 +9,7 @@ Mixxx script file for the **Korg NanoKontrol2** controller.
 
 This script description is a bit more verbose than others, at it tries
 to serve as **tutorial** on how to write your own controller scripts.
-People just interested in the functionallity of the mapping can find
+People just interested in the functionality of the mapping can find
 this in indented bullet points.
 
   ![NanoKontrol2 Layout](http://sinusoid.es/mixco/pic/korg_nanokontrol2.jpg)
@@ -106,7 +106,7 @@ per-deck. We define them here and add the behaviours later.
 
             @loadTrack = c.control(0x2a)
 
-Here are some more controls that get their actual functionallity
+Here are some more controls that get their actual functionality
 defined later.
 
             @sync = c.control(0x29)

--- a/script/maudio_xponent.mixco.litcoffee
+++ b/script/maudio_xponent.mixco.litcoffee
@@ -7,7 +7,7 @@ script.xponent
 
 Mixxx script file for the **M-Audio Xponent** controller. The numbers
 in the following picture will be used in the script to describe the
-functionallity of the controls.
+functionality of the controls.
 
   ![Xponent Layout](http://sinusoid.es/mixco/pic/maudio_xponent.png)
 
@@ -163,7 +163,7 @@ channel.
 
 ### The transport section
 
-* **29.** Song progress indication. When it approches the end of the
+* **29.** Song progress indication. When it approaches the end of the
   playing song it starts blinking.
 
             c.output(outCcId 0x14).does b.playhead g
@@ -210,7 +210,7 @@ channel.
 
             c.control(noteId 0x1F).does g, "beats_translate_curpos"
 
-- The *minus* (-) button plays the track in reverese.
+- The *minus* (-) button plays the track in reverse.
 
             c.control(noteId 0x20).does g, "reverse"
 
@@ -371,7 +371,7 @@ Initialization
 
 Unlike old Mixxx versions, this script initializes the device properly
 for light feedback.  The trick of holding the two and key button on
-initalization are no longer required.
+initialization are no longer required.
 
         preinit: ->
             msg = [0xF0, 0x00, 0x20, 0x08, 0x00, 0x00, 0x63, 0x0E,

--- a/script/novation_twitch.mixco.js
+++ b/script/novation_twitch.mixco.js
@@ -115,7 +115,7 @@ mixco.script.register(module, {
         c.input(ccIdFxBanks(0x2))
             .does("[EffectRack1_EffectUnit1]", "chain_selector")
 
-        // * The *on/off* button of the FX section completley toggles
+        // * The *on/off* button of the FX section completely toggles
         //   the first effect unit.
 
         c.control(c.noteIds(0x22, 0xB))

--- a/src/behaviour.litcoffee
+++ b/src/behaviour.litcoffee
@@ -5,7 +5,7 @@ mixco.behaviour
 > - **View me [on a static web](http://sinusoid.es/mixco/src/behaviour.html)**
 > - **View me [on GitHub](https://github.com/arximboldi/mixco/blob/master/src/behaviour.litcoffee)**
 
-This module contains all the functionallity that lets you add
+This module contains all the functionality that lets you add
 *behaviour* to the hardware *controls* -- i.e. determine what they do.
 
     events    = require 'events'
@@ -51,7 +51,7 @@ This `option` object contains all the available options in Mixxx, with
 names converted to idiomatic JavaScript -- e.g. *soft-takeover* becomes
 *softTakeover*.
 
-These impementations are simplifications of what there is in
+These implementations are simplifications of what there is in
 `MidiController::computeValue` in Mixxx.  Please check them from time
 to time.  Also the way we implement non-linear transforms is
 inconsistent with how Mixxx does it, but it should be though.
@@ -122,7 +122,7 @@ Behaviours
 ----------
 
 A **Behaviour** determines how a control should behave under some
-circunstances. In general, behaviours are values also, so one can
+circumstances. In general, behaviours are values also, so one can
 listen to them.
 
     class exports.Behaviour extends value.Value
@@ -309,7 +309,7 @@ to listen to it.
                 key:   @key
 
 While in general mappings are done directly, bypassing the script,
-under some circunstances it might happen that they are proccessed in
+under some circumstances it might happen that they are processed in
 the script.  In this case, we define `onMidiEvent` to emulate the
 behaviour of a direct mapping.
 
@@ -383,7 +383,7 @@ handler to it.
     exports.mapOut = factory exports.MapOut
 
 
-#### Combinatios
+#### Combinations
 
 The **map** behaviour is the most common one.  It maps both input and
 output to a control in Mixxx.
@@ -421,7 +421,7 @@ enabled.
     exports.soft = ->
         exports.map(arguments...).option(option.softTakeover)
 
-The *set* behaviour sets a control to a spefic value whenever it is
+The *set* behaviour sets a control to a specific value whenever it is
 pressed.  The *toggle* behaviour instead sets it to two different
 value on press or release.
 
@@ -460,7 +460,7 @@ There are two ways of using it:
 
 The **add** method adds an option and returns the activator for
 it. The parameter *listen* is a second optional key that is used for
-retreiving the value as opposed to setting it.
+retrieving the value as opposed to setting it.
 
         add: (group, key, listen=null) ->
             idx       = @_chooseOptions.length
@@ -636,7 +636,7 @@ methods of the `control.Control` class.
 
 
 Conditional behaviours can not be directly mapped, as they have to
-determine, in the script, wether they are enabled or not.
+determine, in the script, whether they are enabled or not.
 
         directOutMapping: -> null
         directInMapping: -> null
@@ -730,7 +730,7 @@ equivalent methods in the engine.
             @script.mixxx.engine.brake deck, @value, args...
 
 The **playhead** sends the current position meter a MIDI value and
-blinks faster and faster as the play position aproaches the end of the
+blinks faster and faster as the play position approaches the end of the
 track.
 
     exports.playhead = (g) ->

--- a/src/cli.litcoffee
+++ b/src/cli.litcoffee
@@ -310,7 +310,7 @@ extension for the main script, where `mixco.script.register` is called.
 
 The **main** function finally implements the meat of the command line
 script.  It parses the arguments, sets up the logger and starts the
-appropiate task.
+appropriate task.
 
     exports.main = ->
         argv = args()

--- a/src/control.litcoffee
+++ b/src/control.litcoffee
@@ -157,7 +157,7 @@ the scripts base class.
 
 ### Input
 
-An *input control* can proccess inputs from the hardware.
+An *input control* can process inputs from the hardware.
 
     class exports.InControl extends exports.Control
 

--- a/src/script.litcoffee
+++ b/src/script.litcoffee
@@ -24,7 +24,7 @@ Script
 First, the **register** function registers a instance of the class
 `scriptTypeOrDefinition` instance into the given module.
 `scriptTypeOrDefinition` can be either a `Script` subclass or an
-object definining overrides for `name`, `constructor` and optionally
+object defining overrides for `name`, `constructor` and optionally
 `init` and `shutdown`. The script instance will be exported as
 `Script.name`, and if the parent module is main, it will be executed.
 
@@ -127,7 +127,7 @@ not have to care about it.
 ### Properties
 
 This is the metadata that is displayed in the Mixx preferences
-panel. Overide it with your details.
+panel. Override it with your details.
 
         info:
             name: "[mixco] Generic Script"
@@ -154,7 +154,7 @@ Use **add** to add controls to your script instance.
 
 ### Mixxx protocol
 
-These methos are called by Mixxx when the script is loaded or
+These methods are called by Mixxx when the script is loaded or
 unloaded.
 
         init: catching ->

--- a/test/mixco/behaviour.spec.coffee
+++ b/test/mixco/behaviour.spec.coffee
@@ -160,7 +160,7 @@ describe 'mixco.behaviour', ->
             output.output.value = 1
             expect(actor.send).to.have.been.calledWith 'on'
 
-        it 'sends "on" value when value is bellow minimum', ->
+        it 'sends "on" value when value is below minimum', ->
             output.enable {}, actor
             output.output.value = 1
             output.output.value = 0
@@ -610,7 +610,7 @@ describe 'mixco.behaviour', ->
             script    = mocks.testScript()
             when_     = behaviour.when condition, wrapped
 
-        it "does nothing when enabled and condition not satisifed", ->
+        it "does nothing when enabled and condition not satisfied", ->
             when_.enable script, actor
             expect(wrapped.enable).
                 not.to.have.been.called
@@ -684,7 +684,7 @@ describe 'mixco.behaviour', ->
             expect(wrapped2.actor).not.to.exist
             expect(wrapped3.actor).to.exist
 
-        it "exposes wether it meets the condition on its 'value'", ->
+        it "exposes whether it meets the condition on its 'value'", ->
             when_.enable script, actor
             condition.value = true
             expect(when_.value).to.be.true

--- a/test/scripts.spec.coffee
+++ b/test/scripts.spec.coffee
@@ -100,7 +100,7 @@ describe 'scripts', ->
                 script.init()
                 script.shutdown()
 
-            # The next is specially usefull.  Missing entries in the
+            # The next is specially useful.  Missing entries in the
             # `mixco.transform` table are often found by these, among
             # other trivial problems in the user scripts.
             #


### PR DESCRIPTION
Found via `codespell -q 3`